### PR TITLE
[26기 옥원철 ]Modified: 추천도서 이미지 hover 시 책 정보 노출

### DIFF
--- a/src/pages/Main/Recommendation/Recommendation.scss
+++ b/src/pages/Main/Recommendation/Recommendation.scss
@@ -24,6 +24,7 @@
 
   .recommendedBook {
     display: flex;
+    position: relative;
   }
 
   .rcmDesc {
@@ -37,7 +38,7 @@
     display: none;
   }
 
-  p {
+  .rcmDesc p {
     margin-bottom: 10px;
   }
 
@@ -50,6 +51,38 @@
     font-size: 2rem;
   }
 
+  .imgWrap {
+    position: relative;
+  }
+
+  .bookInfo {
+    @include flexDirectColumn;
+    justify-content: center;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    text-align: center;
+    width: 270px;
+    height: 360px;
+    background-color: black;
+    color: white;
+    opacity: 0;
+    transition: all 0.1s linear;
+  }
+
+  .bookInfo:hover {
+    opacity: 0.6;
+  }
+
+  .bookInfo p {
+    margin: 15px 0px;
+  }
+
+  .bookTitle {
+    font-size: 1.5rem;
+  }
+
   .rcmBookImg {
     width: 300px;
     height: 400px;
@@ -58,7 +91,7 @@
   }
 
   .rcmBookImg:hover {
-    transform: scale(1.1);
+    // transform: scale(1.1);
     cursor: pointer;
   }
 

--- a/src/pages/Main/Recommendation/RecommendedBook.js
+++ b/src/pages/Main/Recommendation/RecommendedBook.js
@@ -2,8 +2,15 @@ import React, { Component } from 'react';
 
 export class RecommendedBook extends Component {
   render() {
-    const { headDesc, detailDesc1, detailDesc2, imgSrc, name } =
-      this.props.recommendationList;
+    const {
+      headDesc,
+      detailDesc1,
+      detailDesc2,
+      imgSrc,
+      name,
+      author,
+      issueDate,
+    } = this.props.recommendationList;
 
     return (
       <div className="recommendedBook">
@@ -12,7 +19,14 @@ export class RecommendedBook extends Component {
           <p className="detailDesc">{detailDesc1}</p>
           <p className="detailDesc">{detailDesc2}</p>
         </div>
-        <img className="rcmBookImg" src={imgSrc} alt={name} />
+        <div className="imgWrap">
+          <img className="rcmBookImg" src={imgSrc} alt={name} />
+          <div className="bookInfo">
+            <p className="bookTitle">{name}</p>
+            <p>{author}</p>
+            <p>{issueDate}</p>
+          </div>
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
Modified: Main 페이지 관련 파일 업데이트

## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [x] 리뷰 반영
- [x] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)

- Main 화면 구현
![스크린샷 2021-11-09 오후 5 34 28](https://user-images.githubusercontent.com/85351198/140889964-20306445-c635-48a3-a203-182c2c14d0b0.png)


<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)

### 1. Main 화면 내 신간도서 및 베스트셀러들을 보여줄 component 작성 - `MainSlides.js`
 - 5권씩 잘라서 메인화면에 띄울 수 있도록 Mock data의 index 단위로 `slice`한 뒤, index를 변경하는 함수(`showAfter`, `showBefore`)를 작성하여 화면 슬라이드 기능 구현
![NewIssueSlide](https://user-images.githubusercontent.com/85351198/140888247-14effb65-3027-4719-8021-7ebedbc69995.gif)
 - `Main.js`에서 `props`로 `MainSlides.js`에 변경값을 전달하여 컴포넌트 재사용

<br />

### 2.  추천도서 목록을 보여줄 component 작성 - `Recommendation.js`
 - 상기 `MainSlides.js`와 같은 로직으로 화면에 데이터를 렌더링
 - <span style="color: blue"> 도서 이미지에 마우스 hover 시 책 제목, 저자 및 출간일 정보가 드러나도록 스타일 구현 </span>


<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- 라이브러리를 활용하지 않고 화면에 렌더링 되는 목록을 변경하기 위한 로직을 구현하기 위해서, Mock data를 slice하고 state를 통해서 slice하고자 하는 배열의 인덱스를 변경하는 방법을 고민해보았습니다. 
- 같은 로직을 사용하는데도 불구하고 분리되어 있었던 컴포넌트(Bestseller, NewIssue)를 통합하는 과정에서 컴포넌트 재사용에 대한 개념을 익혔습니다.
- 자식요소에 `props`로 넘겨줘야 할 데이터가 다양할 경우, 데이터 전체를 `props`로 넘긴 뒤 자식 요소에서 구조분해할당을 활용하는 방법을 배웠습니다.
-  [react icons](https://react-icons.github.io/react-icons) 에서 아이콘들을 import 해오는 법을 배웠습니다.
<br />
- 공통으로 사용하는 `variables.scss`를 통해 scss 스타일 변수를 활용할 수 있습니다.

## :: 기타 질문 및 특이 사항
- 
